### PR TITLE
Optimise production build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /coverage
 .env
 .DS_Store
+/server/dist

--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   "main": "index.js",
   "scripts": {
     "dev": "babel-watch server/server.js",
-    "start": "NODE_ENV=production node server/dist/server.js", 
+    "start": "NODE_ENV=production node server/dist/server.js",
     "start-dev": "npm run build:dev && babel-node server/server.js",
     "dev-test": "jest",
     "build:dev": "webpack --config ./webpack.config.js",
     "build:client": "webpack -p --config ./webpack.config.prod.js",
     "build:server": "rimraf server/dist/ && babel ./server --out-dir ./server/dist/ --copy-files",
-    "build":"concurrently \"npm run build:client\" \"npm run build:server\"",
+    "build": "concurrently \"npm run build:client\" \"npm run build:server\"",
     "postinstall": "[\"$NODE_ENV\" != production ] && exit 0; npm run build",
     "coverage": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "test": "jest --coverage && npm run coverage"
@@ -65,6 +65,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-watch": "^2.0.6",
     "body-parser": "^1.17.2",
+    "concurrently": "^3.5.0",
     "css-loader": "^0.28.4",
     "dotenv": "^4.0.0",
     "express": "^4.15.3",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,14 @@
   "main": "index.js",
   "scripts": {
     "dev": "babel-watch server/server.js",
-    "start": "npm run build && babel-node server/server.js",
+    "start": "NODE_ENV=production node server/dist/server.js", 
     "start-dev": "npm run build:dev && babel-node server/server.js",
     "dev-test": "jest",
     "build:dev": "webpack --config ./webpack.config.js",
-    "build": "webpack -p --config ./webpack.config.prod.js",
+    "build:client": "webpack -p --config ./webpack.config.prod.js",
+    "build:server": "rimraf server/dist/ && babel ./server --out-dir ./server/dist/ --copy-files",
+    "build":"concurrently \"npm run build:client\" \"npm run build:server\"",
+    "postinstall": "[\"$NODE_ENV\" != production ] && exit 0; npm run build",
     "coverage": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "test": "jest --coverage && npm run coverage"
   },

--- a/server/server.js
+++ b/server/server.js
@@ -18,25 +18,29 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 
 
-const config= require('../webpack.config');   // eslint-disable-line
-const compiler = webpack(config);
-if (process.env.NODE_ENV === 'development') {
+if (process.env.NODE_ENV !== 'production') {
+  const config= require('../webpack.config');   // eslint-disable-line
+  const compiler = webpack(config);
   app.use(webpackMiddleWare(compiler, {
     hot: true,
     publicPath: config.output.publicPath,
     noInfo: true,
   }));
   app.use(webpackHotMiddleWare(compiler));
+
+  app.use(express.static(path.join(__dirname, '../dist')));
+
+  app.get('*', (req, res) => {
+    res.sendFile(path.join(__dirname, '../dist/index.html'));
+  });
+} else {
+  app.use(express.static(path.join(__dirname, '../../dist')));
+
+  app.get('*', (req, res) => {
+    res.sendFile(path.join(__dirname, '../../dist/index.html'));
+  });
 }
 
-app.use(express.static(path.join(__dirname, '../dist')));
-
-// use routes imported
 routes(app);
-
-// default route
-app.get('*', (req, res) => {
-  res.sendFile(path.join(__dirname, '../dist/index.html'));
-});
 
 app.listen(port);


### PR DESCRIPTION
#### What does this PR do?
This PR removes the need for babel-node on the production build. It instead transpiles the server side to a seperate dist folder and runs the app from that folder.

#### Description of task to be completed
Modify build scripts to transpile down to es5, remove babel-node for production purposes.

#### How should this be manually tested
Clone the chore/task-runner branch and run `npm run start`. Go to your browser and navigate to http://localhost:6969

#### Background context
Babel-node should not be used on the production server cause of it's heavy memory usage and also the fact that the entire app has to be compiled on the fly. See [here](https://babeljs.io/docs/usage/cli/#babel-node)
