### PR TITLE
bug(google-user): update instead of set fields

### DIFF
--- a/client/src/actions/googleSignInAction.js
+++ b/client/src/actions/googleSignInAction.js
@@ -15,7 +15,7 @@ export default function GoogleSignInAction() {
     .then((result) => {
       const user = result.user;
       // save the user details to the database
-      database.ref(`users/${user.uid}`).set({
+      database.ref(`users/${user.uid}`).update({
         username: user.displayName,
         email: user.email
       });


### PR DESCRIPTION
#### What does this PR do?
This PR fixes a bug with the users that sign in with Google.

#### How can this be manually tested
Previously, signing out and in of the app as a Google user removes all previously persisted data, now signing out and in doesn't remove the user's data.