### PR TITLE
Feedback/concrete tests

### DIFF
--- a/__mocks__/nexmo.js
+++ b/__mocks__/nexmo.js
@@ -1,7 +1,7 @@
 /* global jest */
 
 export const message = {
-  sendSms: jest.fn()
+  sendSms: () => jest.fn()
 };
 
 /**

--- a/client/__tests__/stores/AllUsersStore.test.js
+++ b/client/__tests__/stores/AllUsersStore.test.js
@@ -82,19 +82,27 @@ describe('PostItAllUsersStore ', () => {
 
   it('should update user list after getting new values', () => {
     callback(recieveUsers);
-    expect((PostItAllUsersStore.getUsers('testGroupId')).size).toBe(1);
+    const usersMap = PostItAllUsersStore.getUsers('testGroupId');
+    const userKeys = usersMap.keySeq().toArray();
+    expect(userKeys.length).toBe(1);
+    expect(userKeys[0]).toBe('testUser');
   });
 
   it('should merge a new list with former list when user list updates',
     () => {
       callback(recieveUsers);
       callback(recieveNewUsers);
-      expect((PostItAllUsersStore.getUsers('testGroupId')).size).toBe(3);
+      const usersMap = PostItAllUsersStore.getUsers('testGroupId');
+      const userKeys = usersMap.keySeq().toArray();
+      expect(userKeys).toEqual(['testUser', 'testUser2', 'testUser3']);
     });
 
   it('should clear user list when clear store action is called ', () => {
     callback(recieveUsers);
-    expect((PostItAllUsersStore.getUsers('testGroupId')).size).toBe(1);
+    const usersMap = PostItAllUsersStore.getUsers('testGroupId');
+    const userKeys = usersMap.keySeq().toArray();
+    expect(userKeys.length).toBe(1);
+    expect(userKeys[0]).toBe('testUser');
     callback(clearUsers);
     expect(PostItAllUsersStore.getUsers('testGroupId')).not.toBeDefined();
   });

--- a/client/__tests__/stores/GroupStore.test.js
+++ b/client/__tests__/stores/GroupStore.test.js
@@ -1,4 +1,5 @@
 import PostItActionTypes from '../../src/ActionTypes';
+import groupList from '../../src/models/groupList';
 
 /* global jest */
 
@@ -6,7 +7,7 @@ jest.mock('../../src/Dispatcher');
 
 describe('PostItGroupStore', () => {
   const sampleGroup = new Map();
-  sampleGroup.set('key', 'groupValue');
+  sampleGroup.set('key', {});
   const recieveGroups = {
     action: {
       type: PostItActionTypes.RECIEVE_GROUP_RESPONSE,
@@ -47,7 +48,9 @@ describe('PostItGroupStore', () => {
 
   it('should update group map after recieving dispatch', () => {
     callback(recieveGroups);
-    expect((PostItGroupStore.getGroups()).size).toBe(1);
+    const groupMap = PostItGroupStore.getGroups();
+    const groupKeys = groupMap.keySeq().toArray();
+    expect(groupKeys[0]).toEqual('key');
   });
 
   it('should clear groups on clear groups action', () => {

--- a/client/__tests__/stores/MessageStore.test.js
+++ b/client/__tests__/stores/MessageStore.test.js
@@ -6,11 +6,16 @@ jest.mock('../../src/Dispatcher');
 
 describe('PostItMessageStore', () => {
   // message payload
+  const messages = new Map();
+  messages.set('key', {
+    sender: 'testSender',
+    body: 'test message body'
+  });
   const recieveMessages = {
     action: {
       type: PostItActionTypes.RECIEVE_MESSAGE_RESPONSE,
       Id: 'testId',
-      messages: [['message', 'test-message']]
+      messages
     }
   };
 
@@ -44,7 +49,12 @@ describe('PostItMessageStore', () => {
 
   it('should update map of messages in on recieve callback', () => {
     callback(recieveMessages);
-    expect((PostItMessageStore.getMessage('testId')).size).toBe(1);
+    const messageMap = PostItMessageStore.getMessage('testId');
+    const messageValues = messageMap.valueSeq().toArray();
+    expect(messageValues).toEqual([{
+      body: 'test message body',
+      sender: 'testSender'
+    }]);
   });
 
   it('should emit change on receive mark read dispatch', () => {
@@ -83,7 +93,12 @@ describe('PostItMessageStore', () => {
 
   it('should clear messages for clear message store payload', () => {
     callback(recieveMessages);
-    expect((PostItMessageStore.getMessage('testId')).size).toBe(1);
+    const messageMap = PostItMessageStore.getMessage('testId');
+    const messageValues = messageMap.valueSeq().toArray();
+    expect(messageValues).toEqual([{
+      body: 'test message body',
+      sender: 'testSender'
+    }]);
     callback(clearMessageStore);
     expect((PostItMessageStore.getMessage('testId'))).not.toBeDefined();
   });

--- a/server/__tests__/notificationHelper.test.js
+++ b/server/__tests__/notificationHelper.test.js
@@ -8,7 +8,7 @@ describe('NotificationHelper', () => {
   let nexmoSpy;
   let transporterSpy;
   beforeEach(() => {
-    emails = ['firstemail@email.com', 'secondemail@email.componentDidMount'];
+    emails = ['firstemail@email.com', 'secondemail@email.com'];
     numbers = ['2348128186810'];
     transporterSpy = spyOn(transporter, 'sendMail');
     nexmoSpy = spyOn(message, 'sendSms');
@@ -23,12 +23,20 @@ describe('NotificationHelper', () => {
   it('should call email function only, for urgent messages', () => {
     notificationHelper(emails, numbers, 'urgent');
     expect(nexmoSpy).not.toHaveBeenCalled();
-    expect(transporterSpy).toHaveBeenCalled();
+    expect(transporterSpy).toHaveBeenCalledWith({
+      subject: 'New Message from Post-It',
+      text: 'You have an important message on Post-It, check it out',
+      from: 'postitbyyamen@gmail.com',
+      to: 'secondemail@email.com'
+    }
+    );
   });
 
   it('should call email and sms function for critical messages', () => {
     notificationHelper(emails, numbers, 'critical');
     expect(transporterSpy).toHaveBeenCalled();
-    expect(nexmoSpy).toHaveBeenCalled();
+    expect(nexmoSpy).toHaveBeenCalledWith('Post-It', '2348128186810'
+      , 'You have a critical message on Post-It, login to check now!',
+      { type: 'unicode' });
   });
 });


### PR DESCRIPTION
#### What does this PR do?
This PR improves tests by using more concrete payloads in the test specs for stores, and the notification helper.

#### Description of tasks to be completed
- change 'size' assertion in the group and all-user store tests to concrete values
- assert what nexmo and nodemailer spies are called with

#### Any background context?
Test specs should have concrete values in the test specs for more efficient tests.